### PR TITLE
change the way of protein alignment

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,15 @@
 
 ## Introduction
 
-The purpose of this program is **One-click** user-friendly tool to calculate mutation locations and rates from an alignment file. Of course, there are a lot of more sophisticated tools, but this tool targets the beginner bioinformaticians know minimum of programming.
+The purpose of this program is user-friendly tool to calculate mutation locations and rates from an alignment file. 
+
+This tool targets the beginner bioinformaticians know minimum of programming with minimum function compare to other fancy tools.
 
 The script is written in Python and supports analysis of nucleotide, protein, or both types of alignments.
+
+## Web Implimentation
+
+If you want Web-based version please use [PubMLST](https://pubmlst.org) or [IOI-web-tools](http://google.com) #change here please Broncio.
 
 ## Dependencies
 


### PR DESCRIPTION
Now the mafft with run with higher gap penalty with "--leavegappyregion" option

It now employed different way to deal with stop codon for better quality of alignment.

1. If if face the premature stop codon, it cut the sequence with stop codon and keep the first block
2. It will replace the other sequence with reference sequence (currently first sequence)
3. After the alignment it will cut the alignment result with * again and replace the rest with "-"
4. The "survived count" value will decrease after the * and substitution rate will be calculated depends on this number