### PR TITLE
Fix job_id argument

### DIFF
--- a/mutation_analysis.py
+++ b/mutation_analysis.py
@@ -53,7 +53,7 @@ def parse_arguments():
         help='Keep temporary files generated during the analysis'
     )
     parser.add_argument(
-        '--job-id', default='output',
+        '--job_id', default='output',
         help='Prefix for output files to avoid clashes in multiple runs'
     )
     return parser.parse_args()


### PR DESCRIPTION
Argument is specified as 'job-id' but args.job_id is used. It should be job_id to be consistent with other arguments.